### PR TITLE
feat: allow report generation when using the cypress module api

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ Simply run your Cypress tests as usual. The plugin will automatically generate a
 cypress run
 ```
 
+## API Usage
+
+If you are using the Cypress module API, you can pass the Cypress results to the plugin directly:
+
+```javascript
+const cypress = require('cypress')
+const {createJUnitReport} = require('@saucelabs/cypress-junit-plugin')
+
+cypress.run({
+  reporter: 'spec',
+  browser: 'chrome',
+}).then(r => {
+  createJUnitReport(r, { filename: 'path/to/my_junit.xml' });
+})
+```
+
 ## Contributing
 
 Contributions to the `@saucelabs/cypress-junit-plugin` are welcome! Check out our contributing guidelines for more information on how to participate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "@saucelabs/cypress-junit-plugin",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@saucelabs/cypress-junit-plugin",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "xmlbuilder2": "^3.1.1"
@@ -31,8 +33,7 @@
       },
       "peerDependencies": {
         "cypress": ">=13"
-      },
-      "version": "0.1.0"
+      }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -10582,6 +10583,5 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     }
-  },
-  "version": "0.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@saucelabs/cypress-junit-plugin",
+  "version": "0.1.0",
   "description": "Sauce Cypress JUnit Plugin",
   "main": "lib/index.js",
   "scripts": {
@@ -54,6 +55,5 @@
     "release-it": "^17.0.3",
     "rimraf": "^5.0.5",
     "typescript": "^5.3.3"
-  },
-  "version": "0.1.0"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,10 @@ function parseErrorType(err: string): string {
   return '';
 }
 
+/**
+ * Set up the JUnit plugin for Cypress. A JUnit report will be generated at the
+ * end of the Cypress run.
+ */
 export function setupJUnitPlugin(
   on: PluginEvents,
   config: PluginConfigOptions,
@@ -141,4 +145,33 @@ export function setupJUnitPlugin(
   on('after:run', onAfterRun);
   on('after:spec', onAfterSpec);
   return config;
+}
+
+/**
+ * Create a JUnit report from the results of a Cypress run. You can use this
+ * function when running Cypress via its module API.
+ * If you are using the Cypress CLI, call `setupJUnitPlugin()` from your config
+ * file instead.
+ */
+export function createJUnitReport(
+  results: CypressRunResult | CypressFailedRunResult,
+  opts?: ConfigOptions,
+) {
+  reporter = new Reporter(
+    opts || {
+      filename: 'junit.xml',
+    },
+  );
+
+  if (isFailedRunResult(results)) {
+    onAfterRun(results);
+    return;
+  }
+
+  reporter.setSuiteName(`Cypress Test - ${results.browserName}`);
+  results.runs.forEach((run) => {
+    onAfterSpec(run.spec, run);
+  });
+
+  onAfterRun(results);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import BeforeRunDetails = Cypress.BeforeRunDetails;
 import PluginConfigOptions = Cypress.PluginConfigOptions;
 import PluginEvents = Cypress.PluginEvents;
 import Spec = Cypress.Spec;
-import { ConfigOption } from './type';
+import { ConfigOptions } from './type';
 import { Reporter, TestCase, TestSuite } from './reporter';
 
 let reporter: Reporter;
@@ -124,7 +124,7 @@ function parseErrorType(err: string): string {
 export function setupJUnitPlugin(
   on: PluginEvents,
   config: PluginConfigOptions,
-  opts?: ConfigOption,
+  opts?: ConfigOptions,
 ) {
   reporter = new Reporter(
     opts || {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import PluginConfigOptions = Cypress.PluginConfigOptions;
 import PluginEvents = Cypress.PluginEvents;
 import Spec = Cypress.Spec;
 import { ConfigOption } from './type';
-import Reporter, { TestCase, TestSuite } from './reporter';
+import { Reporter, TestCase, TestSuite } from './reporter';
 
 let reporter: Reporter;
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -55,7 +55,7 @@ export class TestCase implements JUnitTestCase {
   }
 }
 
-export default class Reporter {
+export class Reporter {
   public rootSuite: JUnitTestSuite;
   private opts: ConfigOption;
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -6,7 +6,7 @@ import type {
   Failure,
   Error,
   Property,
-  ConfigOption,
+  ConfigOptions,
 } from './type';
 import { create } from 'xmlbuilder2';
 
@@ -57,9 +57,9 @@ export class TestCase implements JUnitTestCase {
 
 export class Reporter {
   public rootSuite: JUnitTestSuite;
-  private opts: ConfigOption;
+  private opts: ConfigOptions;
 
-  constructor(opts: ConfigOption) {
+  constructor(opts: ConfigOptions) {
     this.rootSuite = new TestSuite();
     this.opts = opts;
   }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,7 +1,7 @@
 /**
  * Defines the structure for configuration options.
  */
-export interface ConfigOption {
+export interface ConfigOptions {
   // Name/path of the JUnit file.
   filename: string;
 }


### PR DESCRIPTION
## Description

Prior to this change, the user could only generate reports when the plugin was configured to listen to the Cypress event hooks from the Cypress config file.

Expose a new function that allows the plugin to be used together with the Cypress module API.